### PR TITLE
打印功能中的`下落方块检查`同时对填充功能生效

### DIFF
--- a/src/main/java/me/aleksilassila/litematica/printer/config/Configs.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/config/Configs.java
@@ -267,6 +267,11 @@ public class Configs extends ConfigBuilders implements IConfigHandler {
                 .range(0, 64)
                 .build();
 
+        // 下落方块检查
+        public static final ConfigBoolean FALLING_CHECK = bool("printFallingBlockCheck")
+            .defaultValue(true)
+            .build();
+
         // 快捷潜影盒 - 开关
         public static final ConfigBoolean QUICK_SHULKER = bool("quickShulker")
                 .defaultValue(false)
@@ -293,6 +298,7 @@ public class Configs extends ConfigBuilders implements IConfigHandler {
                 PLACE_INTERVAL,
                 PLACE_BLOCKS_PER_TICK,
                 PLACE_COOLDOWN,
+                FALLING_CHECK,
                 STORE_ORDERLY,
                 QUICK_SHULKER,
                 QUICK_SHULKER_MODE,
@@ -451,11 +457,6 @@ public class Configs extends ConfigBuilders implements IConfigHandler {
                 .setVisible(FILL_COMPOSTER::getBooleanValue)
                 .build();
 
-        // 下落方块检查
-        public static final ConfigBoolean FALLING_CHECK = bool("printFallingBlockCheck")
-                .defaultValue(true)
-                .build();
-
         // 破坏错误方块
         public static final ConfigBoolean BREAK_WRONG_BLOCK = bool("printBreakWrongBlock")
                 .defaultValue(false)
@@ -485,7 +486,6 @@ public class Configs extends ConfigBuilders implements IConfigHandler {
                 REPLACEABLE_LIST,
                 SKIP_WATERLOGGED_BLOCK,
                 PRINT_ICE_FOR_WATER,
-                FALLING_CHECK,
                 SAFELY_OBSERVER,
                 STRIP_LOGS,
                 NOTE_BLOCK_TUNING,

--- a/src/main/java/me/aleksilassila/litematica/printer/handler/handlers/FillHandler.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/handler/handlers/FillHandler.java
@@ -107,7 +107,7 @@ public class FillHandler extends ClientPlayerTickHandler {
                 if (Configs.Print.FALLING_CHECK.getBooleanValue() &&
                     player.getMainHandItem().getItem() instanceof BlockItem item &&
                     item.getBlock() instanceof FallingBlock block &&
-                    level.getBlockState(blockPos.below()).isAir()
+                    FallingBlock.isFree(level.getBlockState(blockPos.below()))
                 ) {
                     MessageUtils.setOverlayMessage("方块 " + block.getName().getString() + " 下方无支撑，跳过放置");
                     return;

--- a/src/main/java/me/aleksilassila/litematica/printer/handler/handlers/FillHandler.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/handler/handlers/FillHandler.java
@@ -104,10 +104,10 @@ public class FillHandler extends ClientPlayerTickHandler {
                 || Configs.Print.REPLACEABLE_LIST.getStrings().stream().anyMatch(s -> LitematicaUtils.matchName(s, currentState))
         ) {
             if (handheld || InventoryUtils.switchToItems(player, this.fillModeItemList)) {
-                if (Configs.Print.FALLING_CHECK.getBooleanValue() &&
+                if (Configs.Placement.FALLING_CHECK.getBooleanValue() &&
                     player.getMainHandItem().getItem() instanceof BlockItem item &&
                     item.getBlock() instanceof FallingBlock block &&
-                    level.getBlockState(blockPos.below()).isAir()
+                    FallingBlock.isFree(level.getBlockState(blockPos.below()))
                 ) {
                     MessageUtils.setOverlayMessage("方块 " + block.getName().getString() + " 下方无支撑，跳过放置");
                     return;

--- a/src/main/java/me/aleksilassila/litematica/printer/handler/handlers/FillHandler.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/handler/handlers/FillHandler.java
@@ -10,10 +10,13 @@ import me.aleksilassila.litematica.printer.printer.ActionManager;
 import me.aleksilassila.litematica.printer.utils.ConfigUtils;
 import me.aleksilassila.litematica.printer.utils.LitematicaUtils;
 import me.aleksilassila.litematica.printer.utils.InventoryUtils;
+import me.aleksilassila.litematica.printer.utils.MessageUtils;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.FallingBlock;
 import net.minecraft.world.level.block.LiquidBlock;
 import net.minecraft.world.level.block.state.BlockState;
 
@@ -101,6 +104,15 @@ public class FillHandler extends ClientPlayerTickHandler {
                 || Configs.Print.REPLACEABLE_LIST.getStrings().stream().anyMatch(s -> LitematicaUtils.matchName(s, currentState))
         ) {
             if (handheld || InventoryUtils.switchToItems(player, this.fillModeItemList)) {
+                if (Configs.Print.FALLING_CHECK.getBooleanValue() &&
+                    player.getMainHandItem().getItem() instanceof BlockItem item &&
+                    item.getBlock() instanceof FallingBlock block &&
+                    level.getBlockState(blockPos.below()).isAir()
+                ) {
+                    MessageUtils.setOverlayMessage("方块 " + block.getName().getString() + " 下方无支撑，跳过放置");
+                    return;
+                }
+
                 Action action;
                 if (ConfigUtils.getFillModeFacing() != null) {
                     action = new Action()

--- a/src/main/java/me/aleksilassila/litematica/printer/handler/handlers/PrintHandler.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/handler/handlers/PrintHandler.java
@@ -83,7 +83,7 @@ public class PrintHandler extends ClientPlayerTickHandler {
 
     @Override
     protected void executeIteration(BlockPos blockPos, AtomicReference<Boolean> skipIteration) {
-        if (Configs.Print.FALLING_CHECK.getBooleanValue() && ctx.requiredState.getBlock() instanceof FallingBlock) {
+        if (Configs.Placement.FALLING_CHECK.getBooleanValue() && ctx.requiredState.getBlock() instanceof FallingBlock) {
             BlockPos downPos = blockPos.below();
 
             if (level.getBlockState(downPos).isAir()) {


### PR DESCRIPTION
这么改之后我觉得应该把`下落方块检查`这个选项挪到`核心`列表里, 
但是这样的话配置文件里这个选项也要挪位置, 感觉对升级不太友好, 就没动
