### PR TITLE
perf: reduce per-tick overhead, fix FPS drop on empty inventory, skip layer-filtered blocks

### DIFF
--- a/src/main/java/me/aleksilassila/litematica/printer/enums/BlockMatchingType.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/enums/BlockMatchingType.java
@@ -11,7 +11,10 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.Property;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 public enum BlockMatchingType {
@@ -35,11 +38,20 @@ public enum BlockMatchingType {
      */
     CORRECT;
 
+    // Cached replaceSet — avoids new HashSet allocation on every get() call
+    private static List<String> lastReplaceConfig = Collections.emptyList();
+    private static Set<String> replaceSetCache = Collections.emptySet();
 
+    private static Set<String> getReplaceSet() {
+        List<String> current = Configs.Print.REPLACEABLE_LIST.getStrings();
+        if (!current.equals(lastReplaceConfig)) {
+            replaceSetCache = new HashSet<>(current);
+            lastReplaceConfig = new ArrayList<>(current);
+        }
+        return replaceSetCache;
+    }
 
     public static BlockMatchingType get(BlockState requiredState, BlockState currentState, Property<?>... propertiesToIgnore) {
-        Set<String> replaceSet = new HashSet<>(Configs.Print.REPLACEABLE_LIST.getStrings());
-
         // 如果两个方块状态完全相同，则返回正确状态
         if (requiredState == currentState) {
             return CORRECT;
@@ -60,12 +72,15 @@ public enum BlockMatchingType {
             }
         }
 
-        // 如果启用了替换功能，且当前方块在可替换列表中，则返回缺失方块状态（实际上这会和破坏额外方块打架）
-        if (Configs.Print.PRINT_REPLACE.getBooleanValue() &&
-                replaceSet.stream().anyMatch(string -> !PinYinSearchUtils.matchName(string, requiredState) &&
-                        PinYinSearchUtils.matchName(string, currentState)) && !requiredState.isAir()
-        ) {
-            return MISSING_BLOCK;
+        // 如果启用了替换功能，且当前方块在可替换列表中，则返回缺失方块状态
+        if (Configs.Print.PRINT_REPLACE.getBooleanValue()) {
+            Set<String> replaceSet = getReplaceSet();
+            if (!replaceSet.isEmpty() &&
+                    replaceSet.stream().anyMatch(string -> !PinYinSearchUtils.matchName(string, requiredState) &&
+                            PinYinSearchUtils.matchName(string, currentState)) && !requiredState.isAir()
+            ) {
+                return MISSING_BLOCK;
+            }
         }
 
         // 其他情况返回错误方块状态
@@ -82,4 +97,3 @@ public enum BlockMatchingType {
         return get(requiredState, currentState, propertiesToIgnore);
     }
 }
-

--- a/src/main/java/me/aleksilassila/litematica/printer/handler/ClientPlayerTickHandler.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/handler/ClientPlayerTickHandler.java
@@ -1,8 +1,11 @@
 package me.aleksilassila.litematica.printer.handler;
 
+import fi.dy.masa.litematica.data.DataManager;
 import fi.dy.masa.litematica.world.SchematicWorldHandler;
 import fi.dy.masa.malilib.config.options.ConfigBoolean;
 import fi.dy.masa.malilib.config.options.ConfigOptionList;
+import fi.dy.masa.malilib.util.LayerMode;
+import fi.dy.masa.malilib.util.LayerRange;
 import lombok.Getter;
 import me.aleksilassila.litematica.printer.config.Configs;
 import me.aleksilassila.litematica.printer.enums.*;
@@ -79,6 +82,11 @@ public abstract class ClientPlayerTickHandler extends ConfigUtils {
     private PrinterBox lastBox;
     @Nullable
     private BlockPos lastPos;
+    // Cached layer state for rebuild detection
+    private int lastLayerMin = Integer.MIN_VALUE;
+    private int lastLayerMax = Integer.MIN_VALUE;
+    @Nullable
+    private Direction.Axis lastLayerAxis = null;
 
     private long lastTickTime = -1L;
 
@@ -170,15 +178,28 @@ public abstract class ClientPlayerTickHandler extends ConfigUtils {
         double effectiveRange = ConfigUtils.getEffectiveRange();
         int currentRange = (int) Math.ceil(effectiveRange);
 
+        // Pre-fetch layer state for rebuild detection and box clamping
+        LayerRange layerRange = DataManager.getRenderLayerRange();
+        LayerMode layerMode = layerRange.getLayerMode();
+        Direction.Axis layerAxis = layerRange.getAxis();
+        int layerMin = layerRange.getLayerMin();
+        int layerMax = layerRange.getLayerMax();
+
         boolean needRebuild = box == null
                 || !box.equals(lastBox)
                 || lastPos == null
                 || !lastPos.closerThan(eyePos, effectiveRange * 0.4)
-                || expandRange != currentRange;
+                || expandRange != currentRange
+                || layerMin != lastLayerMin
+                || layerMax != lastLayerMax
+                || layerAxis != lastLayerAxis;
 
         if (needRebuild) {
             lastPos = eyePos;
             expandRange = currentRange;
+            lastLayerMin = layerMin;
+            lastLayerMax = layerMax;
+            lastLayerAxis = layerAxis;
 
             // 直接用 player 精确位置 ±range 算盒子的整数边界，避免 round() 偏移导致边界方块丢失
             int minX = (int) Math.floor(player.getX() - effectiveRange);
@@ -187,6 +208,30 @@ public abstract class ClientPlayerTickHandler extends ConfigUtils {
             int maxY = (int) Math.ceil(player.getEyeY() + effectiveRange);
             int minZ = (int) Math.floor(player.getZ() - effectiveRange);
             int maxZ = (int) Math.ceil(player.getZ() + effectiveRange);
+
+            // Clamp box to the active render layer so we never iterate outside it
+            if (selectionType != null
+                    && selectionType.getOptionListValue() instanceof SelectionType st
+                    && st == SelectionType.LITEMATICA_RENDER_LAYER
+                    && layerMode != LayerMode.ALL) {
+                switch (layerAxis) {
+                    case Y -> { minY = Math.max(minY, layerMin); maxY = Math.min(maxY, layerMax); }
+                    case X -> { minX = Math.max(minX, layerMin); maxX = Math.min(maxX, layerMax); }
+                    case Z -> { minZ = Math.max(minZ, layerMin); maxZ = Math.min(maxZ, layerMax); }
+                }
+            }
+
+            // Clamp Y for above/below-player selection modes
+            if (selectionType != null) {
+                if (selectionType.getOptionListValue() instanceof SelectionType st) {
+                    if (st == SelectionType.LITEMATICA_SELECTION_BELOW_PLAYER) {
+                        maxY = Math.min(maxY, (int) Math.floor(player.getY()));
+                    } else if (st == SelectionType.LITEMATICA_SELECTION_ABOVE_PLAYER) {
+                        minY = Math.max(minY, (int) Math.ceil(player.getY()));
+                    }
+                }
+            }
+
             box = new PrinterBox(minX, minY, minZ, maxX, maxY, maxZ);
             lastBox = box;
             boxRef.set(box);
@@ -195,7 +240,7 @@ public abstract class ClientPlayerTickHandler extends ConfigUtils {
             box.xIncrement = !Configs.Core.X_REVERSE.getBooleanValue();
             box.yIncrement = !Configs.Core.Y_REVERSE.getBooleanValue();
             box.zIncrement = !Configs.Core.Z_REVERSE.getBooleanValue();
-            
+
             cachedIterator = null;
         }
     }
@@ -277,7 +322,7 @@ public abstract class ClientPlayerTickHandler extends ConfigUtils {
                 addGuiInfo(gui);
             }
     
-            if (canProcessPos(pos) && !isOnCooldown(pos)) {
+            if (!isOnCooldown(pos) && canProcessPos(pos)) {
                 executeIteration(pos, skipIteration);
     
                 if (skipIteration.get() || (maxExecs > 0 && ++execCount >= maxExecs)) {

--- a/src/main/java/me/aleksilassila/litematica/printer/handler/handlers/PrintHandler.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/handler/handlers/PrintHandler.java
@@ -136,6 +136,7 @@ public class PrintHandler extends ClientPlayerTickHandler {
         if (side == null) return;
         Item[] reqItems = action.getRequiredItems(ctx.requiredState.getBlock());
         if (!InventoryUtils.switchToItems(player, reqItems)) {
+            setCooldown(blockPos, ConfigUtils.getPlaceCooldown());
             if (reqItems != null && reqItems.length > 0 && reqItems[0] != null) {
                 if (Configs.Print.USE_REMOTE_CONTAINER.getBooleanValue()
                         && RemoteContainerUtils.tryGetItemFromContainers(reqItems[0])) {

--- a/src/main/java/me/aleksilassila/litematica/printer/handler/handlers/PrintHandler.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/handler/handlers/PrintHandler.java
@@ -19,6 +19,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.*;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
 
 import java.util.Collections;
@@ -74,7 +75,16 @@ public class PrintHandler extends ClientPlayerTickHandler {
     public boolean canProcessPos(BlockPos blockPos) {
         WorldSchematic schematic = SchematicWorldHandler.getSchematicWorld();
         if (schematic == null) return false;
-        this.ctx = new SchematicBlockContext(client, level, schematic, blockPos);
+
+        // Fast path: read states once, skip air and already-correct positions
+        // without allocating SchematicBlockContext or running expensive PlacementGuide logic.
+        BlockState required = schematic.getBlockState(blockPos);
+        if (required.isAir()) return false;
+        BlockState current = level.getBlockState(blockPos);
+        // Block state objects are singletons in Minecraft — identity check is safe and O(1)
+        if (required == current) return false;
+
+        this.ctx = new SchematicBlockContext(client, level, schematic, blockPos, current, required);
 
         if (Configs.Print.PRINT_SKIP.getBooleanValue()) {
             // 缓存 skipSet，避免每次新建 HashSet 和流式匹配开销

--- a/src/main/java/me/aleksilassila/litematica/printer/printer/SchematicBlockContext.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/printer/SchematicBlockContext.java
@@ -32,6 +32,15 @@ public class SchematicBlockContext {
         this.requiredState = schematic.getBlockState(blockPos);
     }
 
+    public SchematicBlockContext(Minecraft client, ClientLevel level, WorldSchematic schematic, BlockPos blockPos, BlockState currentState, BlockState requiredState) {
+        this.client = client;
+        this.level = level;
+        this.schematic = schematic;
+        this.blockPos = blockPos;
+        this.currentState = currentState;
+        this.requiredState = requiredState;
+    }
+
     public static <T extends Comparable<T>> Optional<T> getProperty(BlockState blockState, Property<T> property) {
         return BlockUtils.getProperty(blockState, property);
     }

--- a/src/main/java/me/aleksilassila/litematica/printer/utils/RemoteContainerUtils.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/utils/RemoteContainerUtils.java
@@ -40,6 +40,9 @@ public class RemoteContainerUtils {
         final String itemId;
         int scanIndex;
         boolean triedCache;
+        // True while a network request is in-flight — prevents flooding the server
+        // with multiple scan/get requests for the same item in a single iteration.
+        boolean requestPending;
 
         ItemFetchState(String itemId) {
             this.itemId = itemId;
@@ -48,6 +51,7 @@ public class RemoteContainerUtils {
         void reset() {
             triedCache = false;
             scanIndex = 0;
+            requestPending = false;
         }
     }
 
@@ -118,11 +122,17 @@ public class RemoteContainerUtils {
         String itemId = getItemId(item);
         ItemFetchState state = fetchStates.computeIfAbsent(itemId, ItemFetchState::new);
 
+        // If a request is already in-flight for this item, don't send another one.
+        // Without this guard, every block needing the same item triggers a new
+        // server request in the same iteration, flooding the server and causing lag.
+        if (state.requestPending) return true;
+
         if (!state.triedCache) {
             state.triedCache = true;
             ContainerItemCache.SlotRef ref = ContainerItemCache.INSTANCE.findItem(itemId);
             if (ref != null) {
                 pendingRequests.put(ref.pos(), new PendingRequest(itemId, ref.slot()));
+                state.requestPending = true;
                 RemoteInventoryNetwork.sendGetItemRequest(ref.pos(), itemId, ref.slot());
                 return true;
             }
@@ -131,6 +141,7 @@ public class RemoteContainerUtils {
         while (state.scanIndex < containerList.size()) {
             BlockPos pos = containerList.get(state.scanIndex++);
             if (!ContainerItemCache.INSTANCE.isCached(pos)) {
+                state.requestPending = true;
                 RemoteInventoryNetwork.sendScanContainerRequest(pos);
                 return true;
             }
@@ -148,8 +159,10 @@ public class RemoteContainerUtils {
     private static void onScanResult(
             me.aleksilassila.litematica.printer.network.payload.ScanContainerResultPayload payload) {
         ContainerItemCache.INSTANCE.updateContainer(payload.getPos(), payload.getEntries());
+        // Release the pending flag so the next tryGetItemFromContainers call can proceed.
+        // Don't reset scanIndex — let each state continue from where it left off.
         for (ItemFetchState s : fetchStates.values()) {
-            s.reset();
+            s.requestPending = false;
         }
     }
 


### PR DESCRIPTION
## Summary

Two performance improvements targeting common hot-path bottlenecks in the printer tick loop:

**Commit 1 — reduce per-tick block iteration overhead and fix request flooding**
- `PrintHandler.canProcessPos`: fast-path exit for air/already-correct blocks before creating `SchematicBlockContext`, eliminating redundant `getBlockState()` calls for the common case of a built schematic
- `SchematicBlockContext`: new constructor accepting pre-fetched states to avoid double block-state reads on the hot path
- `BlockMatchingType`: cache `replaceSet` instead of allocating a new `HashSet` on every `get()` call (was invoked thousands of times per tick)
- `RemoteContainerUtils`: add `requestPending` flag to prevent flooding the server with multiple scan requests for the same item in a single iteration pass

**Commit 2 — fix FPS drop on empty inventory and skip layer-filtered blocks at box level**
- `PrintHandler.executeIteration`: set cooldown on failed `switchToItems` so blocks without the required item are skipped cheaply via `isOnCooldown` on subsequent ticks instead of re-running the expensive `guide.getAction` path every iteration
- `ClientPlayerTickHandler.iterateBlocks`: reorder to `!isOnCooldown(pos) && canProcessPos(pos)` so cooled blocks skip the costly evaluation entirely
- `ClientPlayerTickHandler.updateBox`: clamp `PrinterBox` bounds to the active Litematica render layer (SINGLE_LAYER / LAYER_RANGE / ALL_ABOVE / ALL_BELOW); box rebuilds immediately when the layer changes

## Test plan
- [ ] Build without errors
- [ ] Printer works correctly on a loaded schematic
- [ ] No FPS drop when player has an empty inventory near unbuilt blocks
- [ ] Layer filter in Litematica correctly restricts which blocks the printer attempts to place