### PR TITLE
chore: update naming convention

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-common
 
+      # only build.yml. Obtaining a commit hash makes it easier to find commits
+      - name: Get latest short hash
+        run: echo "COMMIT_HASH=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
       - name: Make gradle wrapper executable
         run: chmod +x ./gradlew
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,11 +2,10 @@ name: build
 on:
   push:
     paths-ignore: ['*.md']
-  pull_request:
   workflow_dispatch:
 
 env:
-  IS_THIS_RELEASE: false
+  IS_THIS_CI: true
 
 jobs:
   build:
@@ -18,6 +17,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: '0'
 
       - name: Validate gradle wrapper
         uses: gradle/actions/wrapper-validation@v6
@@ -25,10 +26,11 @@ jobs:
       - name: Setup jdk
         uses: actions/setup-java@v5
         with:
-          java-version: '25'
           distribution: 'temurin'
+          java-version: '25'
 
-      - name: Cache Gradle dependencies (公共缓存)
+      - name: Cache Gradle dependencies
+        id: gradle-cache
         uses: actions/cache@v5
         with:
           path: |
@@ -43,6 +45,7 @@ jobs:
       - name: Make gradle wrapper executable
         run: chmod +x ./gradlew
 
+      # If `step: gradle-cache` fails to cache, start downloading dependencies to reduce build failures
       - name: Download dependencies
         if: |
           steps.gradle-cache.outputs.cache-hit != 'true' ||
@@ -52,9 +55,16 @@ jobs:
       - name: Build fabricWrapper subproject
         run: ./gradlew :fabricWrapper:build
 
-      - name: Capture build artifacts
+      - name: Capture versionpack artifacts
         uses: actions/upload-artifact@v7
         with:
           name: Artifacts
           path: fabricWrapper/build/libs/*.jar
           archive: false
+
+      # providing individual versions of artifacts。 only build.yml
+      - name: Capture single version artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: single-version-artifacts
+          path: fabricWrapper/build/tmp/submods/META-INF/jars/*.jar

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,11 @@
+name: pull_request
+
+on:
+  pull_request:
+
+env:
+  IS_THIS_PR: true
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: '0'
 
       - name: Validate gradle wrapper
         uses: gradle/actions/wrapper-validation@v6
@@ -30,25 +32,40 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: 25
+          java-version: '25'
 
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+      - name: Cache Gradle dependencies
+        id: gradle-cache
+        uses: actions/cache@v5
         with:
-          cache-read-only: true
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ./.gradle
+            ./libs
+          key: ${{ runner.os }}-gradle-common
+          restore-keys: |
+            ${{ runner.os }}-gradle-common
 
-      - name: Build all subprojects
+      - name: Make gradle wrapper executable
+        run: chmod +x ./gradlew
+
+      # If `step: gradle-cache` fails to cache, start downloading dependencies to reduce build failures
+      - name: Download dependencies
+        if: steps.gradle-cache.outputs.cache-hit != 'true'
+        run: ./gradlew dependencies --stacktrace
+
+      - name: Build fabricWrapper subprojects
         run: |
           chmod +x gradlew
           ./gradlew :fabricWrapper:build --stacktrace
-        env:
-          BUILD_RELEASE: true
 
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v6
+      - name: Capture versionpack artifacts
+        uses: actions/upload-artifact@v7
         with:
-          name: build-artifacts
-          path: fabricWrapper/build/libs/
+          name: Artifacts
+          path: fabricWrapper/build/libs/*.jar
+          archive: false
 
       - name: Collect mod jars
         run: |
@@ -60,7 +77,7 @@ jobs:
           ls -l mod-jars
 
       - name: Upload to Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ inputs.target_release_tag || github.ref_name }}
           files: mod-jars/*

--- a/buildSrc/src/main/kotlin/ModProjectExtension.kt
+++ b/buildSrc/src/main/kotlin/ModProjectExtension.kt
@@ -70,12 +70,14 @@ private fun getCommitCountNumber(workDir: File = File(".")): Int? {
 
 private fun getFullProjectVersion(modVersion: String): String {
     val commitCount     = getCommitCountNumber()
-    val isRelease = System.getenv("IS_THIS_RELEASE")?.toBoolean() == true
-    val isCi = System.getenv("CI") == "true" || System.getenv("GITHUB_ACTIONS") == "true"
+    val isRelease       = System.getenv("IS_THIS_RELEASE")?.toBoolean() == true
+    val isPR            = System.getenv("IS_THIS_PR")?.toBoolean() == true
+    val isCi            = System.getenv("IS_THIS_CI")?.toBoolean() == true || System.getenv("CI") == "true" || System.getenv("GITHUB_ACTIONS") == "true"
     val timestampMillis = System.currentTimeMillis()
 
     return when {
         isRelease   -> "${modVersion}-${commitCount}-release"
+        isPR        -> "${modVersion}-${commitCount}-pr"
         else        -> "${modVersion}-${
             if (isCi) "${commitCount}-ci"
             else "${timestampMillis}-development"

--- a/buildSrc/src/main/kotlin/ModProjectExtension.kt
+++ b/buildSrc/src/main/kotlin/ModProjectExtension.kt
@@ -77,7 +77,7 @@ private fun getFullProjectVersion(modVersion: String): String {
     val timestampMillis = System.currentTimeMillis()
 
     return when {
-        isRelease   -> "${modVersion}-${commitCount}-release"
+        isRelease   -> modVersion
         isPR        -> "${modVersion}-${commitHash}-${commitCount}-pr"
         else        -> "${modVersion}-${
             if (isCi) "${commitHash}-${commitCount}-ci"

--- a/buildSrc/src/main/kotlin/ModProjectExtension.kt
+++ b/buildSrc/src/main/kotlin/ModProjectExtension.kt
@@ -70,6 +70,7 @@ private fun getCommitCountNumber(workDir: File = File(".")): Int? {
 
 private fun getFullProjectVersion(modVersion: String): String {
     val commitCount     = getCommitCountNumber()
+    val commitHash      = System.getenv("COMMIT_HASH")
     val isRelease       = System.getenv("IS_THIS_RELEASE")?.toBoolean() == true
     val isPR            = System.getenv("IS_THIS_PR")?.toBoolean() == true
     val isCi            = System.getenv("IS_THIS_CI")?.toBoolean() == true || System.getenv("CI") == "true" || System.getenv("GITHUB_ACTIONS") == "true"
@@ -77,9 +78,9 @@ private fun getFullProjectVersion(modVersion: String): String {
 
     return when {
         isRelease   -> "${modVersion}-${commitCount}-release"
-        isPR        -> "${modVersion}-${commitCount}-pr"
+        isPR        -> "${modVersion}-${commitHash}-${commitCount}-pr"
         else        -> "${modVersion}-${
-            if (isCi) "${commitCount}-ci"
+            if (isCi) "${commitHash}-${commitCount}-ci"
             else "${timestampMillis}-development"
         }"
     }

--- a/buildSrc/src/main/kotlin/ModProjectExtension.kt
+++ b/buildSrc/src/main/kotlin/ModProjectExtension.kt
@@ -2,9 +2,6 @@ import org.gradle.api.Project
 import org.gradle.api.GradleException
 import org.gradle.api.JavaVersion
 import java.io.File
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.TimeZone
 
 fun Project.propOrNull(key: String) = findProperty(key)
 fun Project.prop(key: String) = propOrNull(key) ?: throw GradleException("buildSrc: 属性 $key 未配置/值为空")
@@ -56,32 +53,33 @@ val Project.mixinJavaVersion get() = "JAVA_${javaVersion}"
 
 val Project.fullProjectVersion: String get() = getFullProjectVersion(modVersion)
 
+private fun getCommitCountNumber(workDir: File = File(".")): Int? {
+    return try {
+        val process = ProcessBuilder("git", "rev-list", "--count", "HEAD")
+            .directory(workDir)
+            .redirectErrorStream(true)
+            .start()
+        val output = process.inputStream.bufferedReader().readText().trim()
+        val exitCode = process.waitFor()
+        if (exitCode == 0) output.toInt() else null
+    } catch (e: Exception) {
+        e.printStackTrace()
+        null
+    }
+}
+
 private fun getFullProjectVersion(modVersion: String): String {
+    val commitCount     = getCommitCountNumber()
     val isRelease = System.getenv("IS_THIS_RELEASE")?.toBoolean() == true
     val isCi = System.getenv("CI") == "true" || System.getenv("GITHUB_ACTIONS") == "true"
+    val timestampMillis = System.currentTimeMillis()
 
     return when {
-        isRelease -> modVersion
-        isCi -> {
-            val time = SimpleDateFormat("yyMMdd")
-                .apply { timeZone = TimeZone.getTimeZone("GMT+08:00") }
-                .format(Date())
-                .toString()
-            val buildNumber = System.getenv("GITHUB_RUN_NUMBER")
-            val version = "$modVersion+$time"
-            if (buildNumber != null) {
-                "$version+build.$buildNumber"
-            } else {
-                version
-            }
-        }
-        else -> {
-            val time = SimpleDateFormat("yyMMdd")
-                .apply { timeZone = TimeZone.getTimeZone("GMT+08:00") }
-                .format(Date())
-                .toString()
-            "$modVersion+$time"
-        }
+        isRelease   -> "${modVersion}-${commitCount}-release"
+        else        -> "${modVersion}-${
+            if (isCi) "${commitCount}-ci"
+            else "${timestampMillis}-development"
+        }"
     }
 }
 

--- a/buildSrc/src/main/kotlin/ModProjectExtension.kt
+++ b/buildSrc/src/main/kotlin/ModProjectExtension.kt
@@ -78,9 +78,9 @@ private fun getFullProjectVersion(modVersion: String): String {
 
     return when {
         isRelease   -> modVersion
-        isPR        -> "${modVersion}-${commitHash}-${commitCount}-pr"
+        isPR        -> "${modVersion}-${commitCount}-${commitHash}-pr"
         else        -> "${modVersion}-${
-            if (isCi) "${commitHash}-${commitCount}-ci"
+            if (isCi) "${commitCount}-${commitHash}-ci"
             else "${timestampMillis}-development"
         }"
     }


### PR DESCRIPTION
更新模组命名方式
现在通过仓库commit数来区分版本大小
commit hash便于寻找提交
本地则为时间戳(ms)-development来区分
区分构建：
| 构建分支 | 工件名称 |
| --- | --- |
| release | `litematica-printer-versionpack-1.3-beta.3.jar` |
| pull_request | `litematica-printer-versionpack-1.3-beta.3-1694-62da6d46-pr.jar` |
| ci | `litematica-printer-versionpack-1.3-beta.3-1694-62da6d46-ci.jar` |

移除原有yyMMdd-build.xxx格式
上传single version工件(仅在build.yml中)
新增pull_request.yml, 调用build.yml