### PR TITLE
fix: 修复 Matrix 插件反作弊导致无法使用打印机问题

### DIFF
--- a/src/main/java/me/aleksilassila/litematica/printer/mixin/printer/mc/MixinMultiPlayerGameMode.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/mixin/printer/mc/MixinMultiPlayerGameMode.java
@@ -60,6 +60,7 @@ public abstract class MixinMultiPlayerGameMode implements MultiPlayerGameModeExt
     public InteractionResult litematica_printer$useItemOn(boolean localPrediction, InteractionHand hand, BlockHitResult blockHit) {
         if (localPrediction) {
             //#if MC > 11802
+            this.minecraft.player.swing(hand);
             return useItemOn(minecraft.player, hand, blockHit);
             //#else
             //$$ return useItemOn(minecraft.player, minecraft.level, hand, blockHit);
@@ -70,6 +71,7 @@ public abstract class MixinMultiPlayerGameMode implements MultiPlayerGameModeExt
             return InteractionResult.FAIL;
         }
         //#if MC > 11802
+        this.minecraft.player.swing(hand);
         litematica_printer$startPrediction((sequence) -> new ServerboundUseItemOnPacket(hand, blockHit, sequence));
         //#else
         //$$ litematica_printer$startPrediction((sequence) -> new ServerboundUseItemOnPacket(hand, blockHit));


### PR DESCRIPTION
经过测试， Matrix 反作弊判断玩家放置方块时，如果没有挥手动作，将阻止玩家放置方块。<br>
或许挥手动作可以作为一个配置选项🤔