### PR TITLE
fix: close shulkers only with an empty carried stack

### DIFF
--- a/scripts/verify-quickshulker-close-safety.sh
+++ b/scripts/verify-quickshulker-close-safety.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+quick_shulker="$repo_root/src/main/java/me/aleksilassila/litematica/printer/utils/QuickShulkerUtils.java"
+
+require_text() {
+    local file=$1
+    local text=$2
+    if ! grep -Fq "$text" "$file"; then
+        echo "Missing QuickShulker close-safety contract: $text" >&2
+        exit 1
+    fi
+}
+
+reject_text() {
+    local file=$1
+    local text=$2
+    if grep -Fq "$text" "$file"; then
+        echo "Unsafe QuickShulker close fallback found: $text" >&2
+        exit 1
+    fi
+}
+
+require_text "$quick_shulker" "player.containerMenu != deferredCloseContainer"
+require_text "$quick_shulker" "deferredCloseContainer.getCarried().isEmpty()"
+require_text "$quick_shulker" "if (deferredCloseContainer != null) return;"
+require_text "$quick_shulker" "!inventoryTransferPerformed && container.getCarried().isEmpty()"
+reject_text "$quick_shulker" "MAX_DEFERRED_CLOSE_RETRIES"
+reject_text "$quick_shulker" "deferredCloseRetries"
+
+close_count=$(grep -Fc "player.closeContainer();" "$quick_shulker")
+if [[ $close_count -ne 2 ]]; then
+    echo "Expected exactly two guarded shulker close sites, found $close_count" >&2
+    exit 1
+fi
+
+if ! awk '
+    /player\.closeContainer\(\);/ && index(previous, "getCarried().isEmpty()") == 0 { exit 1 }
+    { previous = $0 }
+' "$quick_shulker"; then
+    echo "Every shulker close site must be directly guarded by an empty carried stack" >&2
+    exit 1
+fi
+
+handler_clear_count=$(grep -Ec '^[[:space:]]*isOpenHandler = false;' "$quick_shulker")
+if [[ $handler_clear_count -ne 2 ]]; then
+    echo "Pending shulker closes must retain the open-handler lock" >&2
+    exit 1
+fi
+
+echo "QuickShulker close-safety source contract passed"

--- a/src/main/java/me/aleksilassila/litematica/printer/utils/QuickShulkerUtils.java
+++ b/src/main/java/me/aleksilassila/litematica/printer/utils/QuickShulkerUtils.java
@@ -47,9 +47,8 @@ public class QuickShulkerUtils {
     private static final List<TrackedShulker> trackedShulkers = new ArrayList<>();
     private static ReturnRequest activeReturnRequest;
     private static TrackedShulker activeShulker;
+    private static AbstractContainerMenu deferredCloseContainer;
     private static int deferredCloseTicks;
-    private static int deferredCloseRetries;
-    private static final int MAX_DEFERRED_CLOSE_RETRIES = 10;
 
     private QuickShulkerUtils() {}
 
@@ -57,14 +56,13 @@ public class QuickShulkerUtils {
         if (shulkerCooldown > 0) {
             shulkerCooldown--;
         }
-        if (deferredCloseTicks > 0 && --deferredCloseTicks == 0) {
+        if (deferredCloseContainer != null && deferredCloseTicks > 0 && --deferredCloseTicks == 0) {
             LocalPlayer player = mc.player;
-            if (player == null || player.containerMenu.equals(player.inventoryMenu)) {
-                deferredCloseRetries = 0;
-            } else if (player.containerMenu.getCarried().isEmpty()
-                    || ++deferredCloseRetries >= MAX_DEFERRED_CLOSE_RETRIES) {
+            if (player == null || player.containerMenu != deferredCloseContainer) {
+                clearDeferredClose();
+            } else if (deferredCloseContainer.getCarried().isEmpty()) {
                 player.closeContainer();
-                deferredCloseRetries = 0;
+                clearDeferredClose();
             } else {
                 deferredCloseTicks = 1;
             }
@@ -250,6 +248,8 @@ public class QuickShulkerUtils {
      * 背包满时只执行归还；背包未满时执行正常取物。
      */
     public static void switchFromShulker() {
+        if (deferredCloseContainer != null) return;
+
         LocalPlayer player = mc.player;
         if (player == null || player.containerMenu.equals(player.inventoryMenu)) {
             isOpenHandler = false;
@@ -260,8 +260,9 @@ public class QuickShulkerUtils {
         Inventory inventory = player.getInventory();
 
         if (activeReturnRequest != null) {
-            returnItemToShulker(player, container, inventory, activeReturnRequest);
-            finishShulkerOperation(player);
+            boolean inventoryTransferPerformed =
+                    returnItemToShulker(player, container, inventory, activeReturnRequest);
+            finishShulkerOperation(player, container, inventoryTransferPerformed);
             return;
         }
 
@@ -297,23 +298,23 @@ public class QuickShulkerUtils {
                             activeShulker.updateContents(getContainerContents(container, ownSlots));
                             itemsToReturn.addLast(new ReturnRequest(returnItem, activeShulker));
                         }
-                        finishShulkerOperation(null);
+                        finishShulkerOperation(player, container, true);
                     } else {
-                        finishShulkerOperation(player);
+                        finishShulkerOperation(player, container, false);
                     }
                     return;
                 }
             }
         }
 
-        finishShulkerOperation(player);
+        finishShulkerOperation(player, container, false);
     }
 
-    private static void returnItemToShulker(LocalPlayer player, AbstractContainerMenu container,
-                                            Inventory inventory, ReturnRequest returnRequest) {
+    private static boolean returnItemToShulker(LocalPlayer player, AbstractContainerMenu container,
+                                               Inventory inventory, ReturnRequest returnRequest) {
         if (mc.gameMode == null) {
             itemsToReturn.removeFirstOccurrence(returnRequest);
-            return;
+            return false;
         }
 
         int ownSlots = container.slots.size() - 36;
@@ -330,34 +331,40 @@ public class QuickShulkerUtils {
                 if (returnRequest.shulker() != null) {
                     returnRequest.shulker().updateContents(getContainerContents(container, ownSlots));
                 }
-                return;
+                return true;
             }
             // 潜影盒无空位 → 移除失效请求，避免死循环
             itemsToReturn.removeFirstOccurrence(returnRequest);
-            return;
+            return false;
         }
         // 物品已不在背包（已被使用）→ 移除失效请求，避免死循环
         itemsToReturn.removeFirstOccurrence(returnRequest);
+        return false;
     }
 
-    private static void finishShulkerOperation(LocalPlayer player) {
+    private static void finishShulkerOperation(LocalPlayer player, AbstractContainerMenu container,
+                                               boolean inventoryTransferPerformed) {
         boolean wasReturn = activeReturnRequest != null;
-        if (player == null) {
-            deferredCloseTicks = 2;
-            deferredCloseRetries = 0;
-        } else {
+        if (!inventoryTransferPerformed && container.getCarried().isEmpty()) {
             player.closeContainer();
-            deferredCloseTicks = 0;
-            deferredCloseRetries = 0;
+            clearDeferredClose();
+        } else {
+            deferredCloseContainer = container;
+            deferredCloseTicks = inventoryTransferPerformed ? 2 : 1;
         }
         shulkerBoxSlot = -1;
-        isOpenHandler = false;
         activeReturnRequest = null;
         activeShulker = null;
         lastNeedItemList.clear();
         if (itemsToReturn.isEmpty()) trackedShulkers.clear();
         // 回塞完成后立即允许下一次潜影盒操作，避免当前打印位置因冷却被跳过
         if (wasReturn) shulkerCooldown = 0;
+    }
+
+    private static void clearDeferredClose() {
+        deferredCloseContainer = null;
+        deferredCloseTicks = 0;
+        isOpenHandler = false;
     }
 
     /** 在玩家背包（跳过快捷栏）中找到包含目标物品的潜影盒，返回背包槽位索引，未找到返回 -1 */


### PR DESCRIPTION
## Summary

- bind deferred closing to the exact shulker container that performed the transfer
- close only after its carried stack is empty; remove the retry-limit force-close fallback
- keep the QuickShulker handler locked while closing is pending and ignore repeated content packets
- apply the same close safety to both extraction and return transfers
- add a rerunnable source-contract regression check

## Why

QuickShulker extraction and return both use two `PICKUP` clicks. Closing while the menu still has a carried stack lets vanilla container removal try to return that stack and can ultimately drop it when no inventory slot accepts it. The current retry limit can therefore turn synchronization or slot-state delays into an item drop.

This change treats an empty carried stack as a hard close invariant. If it remains non-empty, the original container stays pending instead of being force-closed. If the player or active container changes, the pending operation is cancelled without closing the replacement container.

## Verification

- `scripts/verify-quickshulker-close-safety.sh`
- `./gradlew --no-daemon :26.2:build` with JDK 25
- compiled the changed class against the installed Minecraft 26.2 runtime and mod JARs with JDK 25
- inspected generated bytecode for the original-container identity and empty-carried guards
- No items were accidentally discarded during the printing process at a tree factory.

The Gradle build completed successfully. Its only compiler diagnostics were two pre-existing Litematica API deprecation warnings in `LitematicaUtils`.
